### PR TITLE
Expand insider threat risk with detailed description and consequences

### DIFF
--- a/content/risk_register/insider_threat.md
+++ b/content/risk_register/insider_threat.md
@@ -2,7 +2,7 @@
 title: "Insider Threat"
 weight: 20
 risk_key: insider_threat
-description: "An authorised person intentionally or accidentally introduces harmful changes to code, configuration, or infrastructure."
+description: "Authorized personnel (developers, contractors, administrators, or other trusted users) with legitimate access to source code repositories, development environments, production systems, or sensitive data may intentionally or unintentionally compromise the confidentiality, integrity, or availability of software assets."
 mitigations:
   - name: "Code Review"
     url: "/controls/release/code_review/"
@@ -18,3 +18,31 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Insider Threat includes risks of malicious code injection, unauthorized data exfiltration, credential misuse, sabotage of build/deployment pipelines, or negligent security practices that expose systems to exploitation. Additionally, insider threat encompasses scenarios where external attackers have compromised the credentials of legitimate users, enabling them to conduct attacks while masquerading as trusted personnel with valid access. The trusted position and technical knowledge of insiders—or attackers leveraging insider credentials—makes detection difficult and potential impact significant.
+
+- **Malicious code injection** - Inserting backdoors, vulnerabilities, or malicious logic into applications or infrastructure
+- **Compromised credentials** - Attackers using stolen or phished developer/admin credentials to access systems and data
+- **Data exfiltration** - Stealing source code, intellectual property, customer data, or sensitive business information
+- **CI/CD pipeline manipulation** - Tampering with build processes, deployment pipelines, or supply chain components to inject malicious code
+- **Cloud/infrastructure misconfiguration** - Accidentally or intentionally exposing databases, storage, or services to unauthorized access
+
+## Consequences
+The consequences of an insider threat materializing for a financial institution can be severe:
+
+- **Direct Financial Losses:** Fraudulent transactions, theft of funds, unauthorized wire transfers, or manipulation of accounts can result in immediate monetary losses to the institution and its customers.
+
+- **Breach of Data Privacy Regulations:** Unauthorized access to or exfiltration of customer PII can lead to significant fines under regulations like GDPR, CCPA, and GLBA, alongside mandated breach notifications and regulatory scrutiny.
+
+- **Violation of Financial Regulations:** Insider actions compromising system integrity, audit trails, or customer data can breach banking regulations (e.g., SOX, PCI DSS, Basel III) and trigger enforcement actions from regulatory bodies.
+
+- **Reputational Damage:** Public disclosure of insider attacks—particularly those involving customer funds or data—can severely erode customer trust, leading to account closures, deposit flight, and long-term brand damage.
+
+- **Operational Disruption:** Sabotage of critical banking systems, payment processing infrastructure, or core applications can halt operations, impacting customer service and transaction processing capabilities.
+
+- **Loss of Competitive Advantage:** Theft of proprietary trading algorithms, risk models, customer insights, or strategic plans can benefit competitors and undermine market position.
+
+- **Legal Liabilities:** The institution may face lawsuits from affected customers, shareholders, or partners, as well as potential criminal investigations if insider actions involve fraud or data breaches.
+


### PR DESCRIPTION
## Summary

- Expanded the `insider_threat` risk description to cover compromised credentials and the full range of insider threat scenarios
- Added a **Description** section detailing threat vectors: malicious code injection, compromised credentials, data exfiltration, CI/CD pipeline manipulation, and cloud misconfiguration
- Added a **Consequences** section outlining impacts for a financial institution: direct financial losses, regulatory breaches, reputational damage, operational disruption, loss of competitive advantage, and legal liabilities

## Test plan

- [ ] Review rendered risk page for formatting and content accuracy
- [ ] Verify links and layout remain consistent with other risk pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)