### PR TITLE
Add missing mitigating controls for insider threat

### DIFF
--- a/content/risk_register/insider_threat.md
+++ b/content/risk_register/insider_threat.md
@@ -14,6 +14,14 @@ mitigations:
     url: "/controls/runtime/system_access/"
   - name: "Change Records"
     url: "/controls/runtime/change_records/"
+  - name: "Secrets Management"
+    url: "/controls/runtime/secrets_managment/"
+  - name: "Runtime Workload Monitoring"
+    url: "/controls/runtime/workload_monitoring/"
+  - name: "Deployment Controls"
+    url: "/controls/runtime/deployment_controls/"
+  - name: "Training"
+    url: "/controls/training/"
 ---
 
 # {{% param "title" %}}


### PR DESCRIPTION
## Summary
- Adds four missing controls to the insider threat risk register entry: Secrets Management, Runtime Workload Monitoring, Deployment Controls, and Training
- These address credential misuse, detection of unauthorized deployments, pipeline enforcement, and negligent insider behaviour respectively

## Test plan
- [ ] Verify the risk register page renders correctly with the new mitigations linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)