### PR TITLE
Redesign landing page with risks-first layout

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -5,4 +5,4 @@ bookToC: false
 ---
 
 
-{{< map >}}
+{{< home_map >}}

--- a/content/controls/_index.md
+++ b/content/controls/_index.md
@@ -21,3 +21,4 @@ The DevSecOps Framework provides:
 
 {{< /columns >}}
 
+{{< map >}}

--- a/layouts/partials/risk_cards.html
+++ b/layouts/partials/risk_cards.html
@@ -1,0 +1,7 @@
+<div class="card-row">
+  {{ range $index, $page := .Pages.ByWeight }}
+    <a class="risk-card card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
+      {{ $page.LinkTitle }}
+    </a>
+  {{ end }}
+</div>

--- a/layouts/shortcodes/home_map.html
+++ b/layouts/shortcodes/home_map.html
@@ -1,0 +1,37 @@
+<!-- Risks -->
+<a href="/risks/"><h2 class="area-header">Risks</h2></a>
+{{ partial "risk_cards.html" (.Site.GetPage "/risks") }}
+
+<!-- Controls -->
+<a href="/controls/"><h2 class="area-header">Controls</h2></a>
+{{ range $taxonomy_name, $taxonomy := .Site.Taxonomies }}
+  {{ if (eq $taxonomy_name "areas") }}
+    {{ with ($.Site.GetPage (printf "/%s" $taxonomy_name)) }}
+      {{ range $index, $weightedArea := .Pages.ByWeight }}
+
+        <a href="/process/{{ .Page.Data.Term }}">
+          <h3 class="area-subheader">{{ .Page.LinkTitle }}</h3>
+        </a>
+
+        {{ $term := .Page.Data.Term }}
+        {{ with .Site.Taxonomies.areas }}
+          {{ range $area, $cards := . }}
+            {{ if eq $area $term }}
+              <div class="card-row">
+                {{ range $index, $card := $cards }}
+                  <a class="control-card area-{{ $term }} card-index-{{ $index }}" href="{{ .RelPermalink }}">
+                    {{ with .Params.control_code }}
+                    <div class="control-code">{{ . }}:</div>
+                    {{ end }}
+                    {{ .LinkTitle }}
+                  </a>
+                {{ end }}
+              </div>
+            {{ end }}
+          {{ end }}
+        {{ end }}
+
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/layouts/shortcodes/risk_map.html
+++ b/layouts/shortcodes/risk_map.html
@@ -1,7 +1,1 @@
-<div class="risk-card-row">
-  {{ range $index, $page := .Page.Pages.ByWeight }}
-    <a class="risk-card card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
-      {{ $page.LinkTitle }}
-    </a>
-  {{ end }}
-</div>
+{{ partial "risk_cards.html" .Page }}

--- a/themes/hugo-book/assets/_custom.scss
+++ b/themes/hugo-book/assets/_custom.scss
@@ -195,6 +195,7 @@ ul.control-list {
     flex-wrap: wrap;
     gap: 10px;
     padding-top: 10px;
+    max-width: 590px;
 }
 
 .risk-card-row {
@@ -371,4 +372,24 @@ div.control-card:hover {
     background-color: var(--blue-500) !important;
     border-color: var(--blue-500) !important;
     text-decoration: none;
+}
+
+.home-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    align-items: start;
+}
+
+.home-col-controls h3.area-subheader {
+    font-size: 1.2rem;
+    margin-bottom: 0;
+    margin-top: 1em;
+    color: var(--body-font-color);
+}
+
+@media (max-width: 900px) {
+    .home-layout {
+        grid-template-columns: 1fr;
+    }
 }


### PR DESCRIPTION
## Summary

- **Home page** now shows Risks first (all 9 tiles), then Controls organised by area below — replacing the controls-only map
- **Controls page** (`/controls`) gains the full tile map after the existing intro section
- **Risk cards** refactored into a shared `partials/risk_cards.html` so `/risks` and the home page use identical markup and styles
- **Card rows** capped at 5 columns max (590px) on all tile grids

## Test plan

- [ ] Home page shows Risks section followed by Controls section
- [ ] Risk card tiles link correctly to individual risk pages
- [ ] Control card tiles link correctly to individual control pages
- [ ] `/controls` page shows intro content then full tile map
- [ ] `/risks` page still renders correctly via the shared partial
- [ ] Card rows wrap after 5 columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)