### PR TITLE
Introduce SDLC-RISK / SDLC-CTRL identity scheme

### DIFF
--- a/content/controls/build/binary_provenance.md
+++ b/content/controls/build/binary_provenance.md
@@ -1,7 +1,7 @@
 ---
 title: Artifact Binary Provenance
 weight: 20
-control_code: KBC2
+control_code: SDLC-CTRL-0002
 areas: 
  - build
 tldr: Every software running in a production system has known provenance

--- a/content/controls/build/dependencies.md
+++ b/content/controls/build/dependencies.md
@@ -1,7 +1,7 @@
 ---
 title: Dependency Management
 weight: 40
-control_code: KBC4
+control_code: SDLC-CTRL-0004
 areas: 
  - build
 tldr: Every dependency is defined securely, managed, and auditable

--- a/content/controls/build/infrastructure_and_config_management.md
+++ b/content/controls/build/infrastructure_and_config_management.md
@@ -2,7 +2,7 @@
 title: Infrastructure and Configuration Management
 level: 1
 weight: 50
-control_code: KBC5
+control_code: SDLC-CTRL-0005
 tldr: Infrastructure and Configurations are defined "as code" and applied through automation
 rationale: Software defined cloud infrastructure allows auditability, reproducibility and drift detection
 areas: 

--- a/content/controls/build/secrets-scanning.md
+++ b/content/controls/build/secrets-scanning.md
@@ -1,7 +1,7 @@
 ---
 title: Secrets Scanning
 weight: 60
-control_code: KBC6
+control_code: SDLC-CTRL-0006
 level: 1
 areas:
  - build

--- a/content/controls/build/toolchain.md
+++ b/content/controls/build/toolchain.md
@@ -2,7 +2,7 @@
 title: Controlled Build Environment
 level: 3
 weight: 30
-control_code: KBC3
+control_code: SDLC-CTRL-0003
 areas: 
  - build
 tldr: Build environments must be defined as code, ephemeral, and auditable

--- a/content/controls/build/versioncontrol.md
+++ b/content/controls/build/versioncontrol.md
@@ -1,7 +1,7 @@
 ---
 title: Version Control
 weight: 10
-control_code: KBC1
+control_code: SDLC-CTRL-0001
 level: 1
 areas: 
  - build

--- a/content/controls/lifecycle/training.md
+++ b/content/controls/lifecycle/training.md
@@ -7,7 +7,8 @@ areas:
  - lifecycle
 ---
 
-# Training
+# {{% param "title" %}}
+{{< area_head >}}
 
 The team study the [OWASP top 10 security risks](https://owasp.org/www-project-top-ten/)
 and discuss their implications for our software development and operations, at least annually.  New employees and members of the tech team require this as part of our onboarding process.

--- a/content/controls/lifecycle/training.md
+++ b/content/controls/lifecycle/training.md
@@ -2,6 +2,7 @@
 weight: 30
 bookFlatSection: false
 title: "Training"
+control_code: SDLC-CTRL-0017
 areas:
  - lifecycle
 ---

--- a/content/controls/lifecycle/training.md
+++ b/content/controls/lifecycle/training.md
@@ -3,6 +3,9 @@ weight: 30
 bookFlatSection: false
 title: "Training"
 control_code: SDLC-CTRL-0017
+level: 1
+tldr: All team members complete annual security awareness training covering the OWASP Top 10
+rationale: Security awareness reduces the likelihood of negligent or accidental insider threats and ensures every team member understands their responsibilities in the software development lifecycle
 areas:
  - lifecycle
 ---

--- a/content/controls/release/code_review.md
+++ b/content/controls/release/code_review.md
@@ -1,7 +1,7 @@
 ---
 title: Code Review
 weight: 10
-control_code: KRC1
+control_code: SDLC-CTRL-0007
 level: 1
 tldr: Code review is performed on all software changes to production
 rationale: Peer review is an essential mitigation against insider threats, as well as a means of improving knowledge sharing and quality.

--- a/content/controls/release/deployment_approvals.md
+++ b/content/controls/release/deployment_approvals.md
@@ -2,7 +2,7 @@
 title: "Deployment Approvals"
 level: 1
 weight: 40
-control_code: KRC4
+control_code: SDLC-CTRL-0010
 tldr: Deployments are approved
 rationale: To meet segregation of duties requirements, all deploymnents to production are approved by someone other than the person making the change
 areas: 

--- a/content/controls/release/quality.md
+++ b/content/controls/release/quality.md
@@ -2,7 +2,7 @@
 title: Quality Assurance
 level: 1
 weight: 20
-control_code: KRC2
+control_code: SDLC-CTRL-0008
 tldr: Functionality of software is assured prior to production
 rationale: Every change has the potential to introduce regressions in functionality.  By testing our software prior to deployment we manage the risk of production issues.
 areas: 

--- a/content/controls/release/security.md
+++ b/content/controls/release/security.md
@@ -2,7 +2,7 @@
 title: Security Vulnerability Scanning
 level: 1
 weight: 30
-control_code: KRC3
+control_code: SDLC-CTRL-0009
 tldr: Software is scanned for security vulnerabilities prior to deployment
 rationale: Many common security vulnerabilities can be detected with automated tools.  By implementing tools for dependency scanning, SAST, and DAST in the pipeline we can reduce the attack surface of our software
 areas: 

--- a/content/controls/release/service_ownership.md
+++ b/content/controls/release/service_ownership.md
@@ -2,7 +2,7 @@
 title: Service ownership
 level: 1
 weight: 50
-control_code: KRC5
+control_code: SDLC-CTRL-0011
 tldr: All services running in our environments have registered ownership
 rationale: In a diverse software landscape it is essential everyone knows who
   is responsible for maintaince and support

--- a/content/controls/runtime/change_records.md
+++ b/content/controls/runtime/change_records.md
@@ -2,7 +2,7 @@
 title: Change Records
 level: 1
 weight: 10
-control_code: KCC1
+control_code: SDLC-CTRL-0012
 tldr: All systems and services maintain a record of changes
 rationale: To meet our change management requirements, all changes to production systems are recorded permanently
 areas: 

--- a/content/controls/runtime/deployment_controls.md
+++ b/content/controls/runtime/deployment_controls.md
@@ -2,7 +2,7 @@
 title: Deployment Controls
 level: 1
 weight: 20
-control_code: KCC2
+control_code: SDLC-CTRL-0013
 tldr: Deployments controls are enforced in the pipeline and environments
 rationale: Ensuring only compliant, approved software deployments are made to production
 areas: 

--- a/content/controls/runtime/secrets_managment.md
+++ b/content/controls/runtime/secrets_managment.md
@@ -2,7 +2,7 @@
 title: Secrets Management
 level: 1
 weight: 30
-control_code: KCC3
+control_code: SDLC-CTRL-0014
 tldr: Build and runtime secrets are stored securely and documented appropriately
 rationale: Leaked secrets such as api keys, cryptography keys, identity tokens
   are a common attack scenario.

--- a/content/controls/runtime/system_access.md
+++ b/content/controls/runtime/system_access.md
@@ -2,7 +2,7 @@
 title: System Access Controls
 level: 1
 weight: 40
-control_code: KCC4
+control_code: SDLC-CTRL-0015
 tldr: All access to runtime environments requires authentication and audit trails
 rationale: To meet our system access control policy, all access must be approved and auditable
 areas: 

--- a/content/controls/runtime/workload_monitoring.md
+++ b/content/controls/runtime/workload_monitoring.md
@@ -2,7 +2,7 @@
 title: Runtime Workload Monitoring
 level: 1
 weight: 50
-control_code: KCC5
+control_code: SDLC-CTRL-0016
 tldr: Workloads are monitored to alert if any non-compliant or unauthorized change is discovered
 rationale: Real-time closed-loop compliance monitoring is a constant vigil against threats
 areas:

--- a/content/risks/audit_and_compliance_failure.md
+++ b/content/risks/audit_and_compliance_failure.md
@@ -1,6 +1,7 @@
 ---
 title: "Audit and Compliance Failure"
 weight: 60
+risk_id: SDLC-RISK-0006
 risk_key: audit_and_compliance_failure
 description: "Inability to provide evidence of controls to regulators, auditors, or enterprise customers, resulting in reputational or commercial damage."
 mitigations:

--- a/content/risks/configuration_drift.md
+++ b/content/risks/configuration_drift.md
@@ -1,6 +1,7 @@
 ---
 title: "Configuration Drift"
 weight: 80
+risk_id: SDLC-RISK-0008
 risk_key: configuration_drift
 description: "Infrastructure or application configuration diverges from its known, approved state, causing undetected changes in security posture or behaviour."
 mitigations:

--- a/content/risks/credential_and_secret_exposure.md
+++ b/content/risks/credential_and_secret_exposure.md
@@ -1,6 +1,7 @@
 ---
 title: "Credential and Secret Exposure"
 weight: 40
+risk_id: SDLC-RISK-0004
 risk_key: credential_and_secret_exposure
 description: "Leaked or poorly managed secrets enable unauthorised access to production systems, customer data, or CI/CD pipelines."
 mitigations:

--- a/content/risks/environment_breach.md
+++ b/content/risks/environment_breach.md
@@ -1,6 +1,7 @@
 ---
 title: "Environment Breach"
 weight: 90
+risk_id: SDLC-RISK-0009
 risk_key: environment_breach
 description: "External attacker running workloads in our system."
 mitigations:

--- a/content/risks/insider_threat.md
+++ b/content/risks/insider_threat.md
@@ -1,6 +1,7 @@
 ---
 title: "Insider Threat"
 weight: 20
+risk_id: SDLC-RISK-0002
 risk_key: insider_threat
 description: "Authorized personnel (developers, contractors, administrators, or other trusted users) with legitimate access to source code repositories, development environments, production systems, or sensitive data may intentionally or unintentionally compromise the confidentiality, integrity, or availability of software assets."
 mitigations:

--- a/content/risks/supply_chain_compromise.md
+++ b/content/risks/supply_chain_compromise.md
@@ -1,6 +1,7 @@
 ---
 title: "Supply Chain Compromise"
 weight: 10
+risk_id: SDLC-RISK-0001
 risk_key: supply_chain_compromise
 description: "Malicious or tampered software components—including open source libraries, base container images, build tools, or third-party services—are introduced into the software development lifecycle, resulting in compromised applications being built, tested, and deployed to production environments."
 mitigations:

--- a/content/risks/unauthorised_deployment.md
+++ b/content/risks/unauthorised_deployment.md
@@ -1,6 +1,7 @@
 ---
 title: "Unauthorised Deployment"
 weight: 30
+risk_id: SDLC-RISK-0003
 risk_key: unauthorised_deployment
 description: "Software is deployed to production without passing required quality gates, security scans, or approval checks."
 mitigations:

--- a/content/risks/unauthorised_system_access.md
+++ b/content/risks/unauthorised_system_access.md
@@ -1,6 +1,7 @@
 ---
 title: "Unauthorised System Access"
 weight: 70
+risk_id: SDLC-RISK-0007
 risk_key: unauthorised_system_access
 description: "Production environments are accessed by personnel without appropriate authorisation or without full audit trails."
 mitigations:

--- a/content/risks/vulnerable_software_in_production.md
+++ b/content/risks/vulnerable_software_in_production.md
@@ -1,6 +1,7 @@
 ---
 title: "Vulnerable Software in Production"
 weight: 50
+risk_id: SDLC-RISK-0005
 risk_key: vulnerable_software_in_production
 description: "Known vulnerabilities in code or dependencies are exploited in the production environment."
 mitigations:

--- a/layouts/shortcodes/area_head.html
+++ b/layouts/shortcodes/area_head.html
@@ -1,5 +1,5 @@
 <blockquote class="book-hint info">
-  Control Code: {{ .Page.Params.control_code }}
+  Control ID: {{ .Page.Params.control_code }}
 </blockquote>
 <blockquote class="book-hint info">
   TLDR: {{ .Page.Params.tldr }}

--- a/layouts/shortcodes/risk_head.html
+++ b/layouts/shortcodes/risk_head.html
@@ -1,4 +1,7 @@
 <blockquote class="book-hint info">
+  Risk ID: {{ .Page.Params.risk_id }}
+</blockquote>
+<blockquote class="book-hint info">
   {{ .Page.Params.description }}
 </blockquote>
 


### PR DESCRIPTION
## Summary

- Replaces the Kosli-branded `KBC`/`KRC`/`KCC` control codes with a flat, framework-neutral `SDLC-CTRL-000N` scheme (0001–0017)
- Gives risks their first formal identifiers as `SDLC-RISK-000N` (0001–0009), alongside the existing `risk_key` slug (kept for Hugo URL/taxonomy compatibility)
- Assigns `SDLC-CTRL-0017` to the Training control, which previously had no code
- Updates `risk_head.html` to display the new Risk ID badge on each risk page
- Updates `area_head.html` label from "Control Code" to "Control ID"
- No URL changes — all existing links remain valid

## ID assignments

| ID | Name |
|---|---|
| SDLC-RISK-0001 | Supply Chain Compromise |
| SDLC-RISK-0002 | Insider Threat |
| SDLC-RISK-0003 | Unauthorised Deployment |
| SDLC-RISK-0004 | Credential and Secret Exposure |
| SDLC-RISK-0005 | Vulnerable Software in Production |
| SDLC-RISK-0006 | Audit and Compliance Failure |
| SDLC-RISK-0007 | Unauthorised System Access |
| SDLC-RISK-0008 | Configuration Drift |
| SDLC-RISK-0009 | Environment Breach |
| SDLC-CTRL-0001 | Version Control |
| SDLC-CTRL-0002 | Artifact Binary Provenance |
| SDLC-CTRL-0003 | Controlled Build Environment |
| SDLC-CTRL-0004 | Dependency Management |
| SDLC-CTRL-0005 | Infrastructure and Config Management |
| SDLC-CTRL-0006 | Secrets Scanning |
| SDLC-CTRL-0007 | Code Review |
| SDLC-CTRL-0008 | Quality Assurance |
| SDLC-CTRL-0009 | Security Vulnerability Scanning |
| SDLC-CTRL-0010 | Deployment Approvals |
| SDLC-CTRL-0011 | Service Ownership |
| SDLC-CTRL-0012 | Change Records |
| SDLC-CTRL-0013 | Deployment Controls |
| SDLC-CTRL-0014 | Secrets Management |
| SDLC-CTRL-0015 | System Access Controls |
| SDLC-CTRL-0016 | Runtime Workload Monitoring |
| SDLC-CTRL-0017 | Training |

## Test plan

- [x] `hugo server` runs without errors
- [x] Risk pages display `Risk ID: SDLC-RISK-000N` badge
- [x] Control pages display `Control ID: SDLC-CTRL-000N`
- [x] Control cards on homepage and map pages show new IDs
- [x] Training card now shows `SDLC-CTRL-0017`
- [x] No broken internal links

🤖 Generated with [Claude Code](https://claude.com/claude-code)