### PR TITLE
Update color palette to match Kosli brand standards

### DIFF
--- a/themes/hugo-book/assets/_custom.scss
+++ b/themes/hugo-book/assets/_custom.scss
@@ -2,6 +2,27 @@
 
 // @import "plugins/numbered";
 
+// Kosli brand theme overrides (light)
+// These override the theme-light mixin values from _defaults.scss
+:root {
+    --gray-100: #F2F3F6;
+    --gray-200: #ECEEF1;
+    --gray-500: #8E9195;
+
+    --color-link: var(--blue-100);
+    --color-visited-link: var(--blue-050);
+
+    --body-background: #FCFCFF;
+    --body-font-color: #1C1B1B;
+
+    --hint-color-info: #1E55CD;
+    --hint-color-warning: #E5BE65;
+    --hint-color-danger: #C8463A;
+
+    --header-color: #101C2B;
+    --green: #4EAC78;
+}
+
 header {
     background-color: #101C2B;
     height: $header-height;
@@ -306,34 +327,34 @@ h2.area-header{
 }
 
 .control-card.area-lifecycle.card-index-0 {
-    background-color: var(--red-300);
-    border-color: var(--red-400);
+    background-color: var(--orange-300);
+    border-color: var(--orange-400);
 }
 
 .control-card.area-lifecycle.card-index-1 {
-    background-color: var(--red-200);
-    border-color: var(--red-300);
+    background-color: var(--orange-200);
+    border-color: var(--orange-300);
 }
 
 .control-card.area-lifecycle.card-index-2 {
-    background-color: var(--red-100);
-    border-color: var(--red-200);
+    background-color: var(--orange-100);
+    border-color: var(--orange-200);
 }
 
 .control-card.area-lifecycle.card-index-3 {
-    background-color: var(--red-100);
-    border-color: var(--red-100);
+    background-color: var(--orange-100);
+    border-color: var(--orange-100);
 }
 
 .control-card.area-lifecycle.card-index-4 {
-    background-color: var(--red-400);
-    border-color: var(--red-400);
+    background-color: var(--orange-050);
+    border-color: var(--orange-100);
 }
 
 // The default color of the lifecycle card when no index is provided
 .control-card.area-lifecycle {
-    background-color: var(--red-400);
-    border-color: var(--red-300);
+    background-color: var(--orange-050);
+    border-color: var(--orange-100);
 }
 
 .markdown .risk-card {

--- a/themes/hugo-book/assets/_variables.scss
+++ b/themes/hugo-book/assets/_variables.scss
@@ -1,40 +1,60 @@
 /* You can override SASS variables here. */
 
 // @import "plugins/dark";
+
+// Override hint colors with Kosli brand palette
+$hint-colors: (
+  info: #1E55CD,
+  warning: #E5BE65,
+  danger: #C8463A,
+);
+
 :root {
-    --blue-050: #0942C5;
-    --blue-100: #2459D1;
+    // Primary Blues
+    --blue-050: #0041AF;
+    --blue-100: #1E55CD;
     --blue-200: #4B75D9;
     --blue-300: #7293E1;
-    --blue-400: #D0D6E8;
-    --blue-500: #000D40;
-    --green-050: #06A163;
-    --green-100: #29B57D;
-    --green-200: #4FB98C;
-    --green-300: #86CFB0;
+    --blue-400: #B4C5FF;
+    --blue-500: #101C2B;
+    // Green - Compliant
+    --green-050: #006D43;
+    --green-100: #4EAC78;
+    --green-200: #59B281;
+    --green-300: #7FD9A5;
     --green-400: #CBEADD;
-    --green-500: #001D16;
-    --red-050: #D7122B;
-    --red-100: #ED475C;
-    --red-200: #F06173;
-    --red-300: #F38593;
-    --red-400: #FBD5DA;
-    --red-500: #1F0808;
-    --yellow-050: #EEB002;
-    --yellow-100: #F7C22E;
-    --yellow-200: #F8CD54;
-    --yellow-300: #F9D776;
+    --green-500: #004126;
+    // Red - Error
+    --red-050: #A62E25;
+    --red-100: #C8463A;
+    --red-200: #E07060;
+    --red-300: #F0998F;
+    --red-400: #FFB4AA;
+    --red-500: #690003;
+    // Yellow - Warning
+    --yellow-050: #775A04;
+    --yellow-100: #AE8C35;
+    --yellow-200: #E5BE65;
+    --yellow-300: #FFDB8B;
     --yellow-400: #FBE6AA;
-    --yellow-500: #1F1400;
-    --orange-100: #FF8900;
+    --yellow-500: #664C00;
+    // Orange - Lifecycle
+    --orange-050: #8B4B00;
+    --orange-100: #B86500;
+    --orange-200: #FF8900;
+    --orange-300: #FFB35C;
+    --orange-400: #FFD9A8;
+    --orange-500: #5C3200;
+    // Neutral - Surface system
     --neutral-100: #FFFFFF;
     --neutral-200: #F7F9FC;
-    --neutral-300: #E6E7F2;
-    --neutral-400: #CCCFE4;
-    --neutral-500: #969BAC;
-    --black-100: #171C21;
-    --black-200: #626669;
-    --black-300: #B3B4B6;
-    --black-400: #DEDEDE;
-    --black-500: #F7F7F7;
+    --neutral-300: #E1E2E5;
+    --neutral-400: #C5C6CB;
+    --neutral-500: #75777B;
+    // Black - On Surface system
+    --black-100: #1C1B1B;
+    --black-200: #575D63;
+    --black-300: #8E9195;
+    --black-400: #D9D9DD;
+    --black-500: #F2F3F6;
 }


### PR DESCRIPTION
## Summary
- Updated all CSS color tokens in `_variables.scss` to match the official Kosli brand palette (blues, greens, reds, yellows, neutrals)
- Added a full orange tonal scale for Lifecycle Controls, giving them a distinct identity separate from the red Risk cards
- Added Kosli brand theme overrides (grays, link colors, body colors, hint colors) in `_custom.scss` rather than modifying the theme's `_defaults.scss`
- Overrode the `$hint-colors` SCSS map in `_variables.scss` to use Kosli brand info/warning/danger colors

### Color mapping
| Area | Color |
|---|---|
| Build Controls | 🟢 Green (`#006D43` → `#CBEADD`) |
| Process/Release Controls | 🔵 Blue (`#0041AF` → `#B4C5FF`) |
| Runtime/Change Controls | 🟡 Yellow (`#775A04` → `#FBE6AA`) |
| Lifecycle Controls | 🟠 Orange (`#8B4B00` → `#FFD9A8`) — **new, was red** |
| Risks | 🔴 Red (`#A62E25` → `#FFB4AA`) |

### Architecture
All customizations are kept in the intended override files:
- `_variables.scss` — color tokens (CSS custom properties) + `$hint-colors` SCSS override
- `_custom.scss` — theme CSS property overrides (imported last, wins cascade)
- `_defaults.scss` — **unchanged** (theme internals left untouched)

## Test plan
- [x] Homepage renders correctly — risk cards (red), all control card groups (green, blue, yellow, orange) display with correct Kosli brand colors
- [x] Verified header background matches Kosli primary dark (`#101C2B`)
- [x] Verified body background (`#FCFCFF`) and text color (`#1C1B1B`) match Kosli Surface Bright / On Surface
- [x] Verified link color (`#1E55CD`) matches Kosli primary blue
- [x] Verified hint/blockquote border and background use Kosli brand info color (`#1E55CD`)
- [x] Verified control card computed colors: Build (`#006D43`), Process (`#0041AF`), Change (`#775A04`), Lifecycle (`#FFB35C` orange)
- [x] Verified Risk card computed color (`#A62E25`)
- [x] Content page (Version Control) renders correctly with proper typography, link colors, and blockquote styling
- [x] No Hugo build errors
- [x] No browser console errors
- [ ] Visual review on multiple screen sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)