### PR TITLE
Improve UI: dark mode default, risk IDs, control tiles, and link fixes

### DIFF
--- a/content/areas/build/_index.md
+++ b/content/areas/build/_index.md
@@ -2,4 +2,5 @@
 title: Build Controls
 wikipedia: https://en.wikipedia.org/wiki/Bruce_Willis
 weight: 100
+section: build
 ---

--- a/content/areas/change/_index.md
+++ b/content/areas/change/_index.md
@@ -2,4 +2,5 @@
 title: Runtime Controls
 wikipedia: https://en.wikipedia.org/wiki/Bruce_Willis
 weight: 300
+section: runtime
 ---

--- a/content/areas/lifecycle/_index.md
+++ b/content/areas/lifecycle/_index.md
@@ -1,4 +1,5 @@
 ---
 title: Lifecycle Controls
 weight: 400
+section: lifecycle
 ---

--- a/content/areas/process/_index.md
+++ b/content/areas/process/_index.md
@@ -2,4 +2,5 @@
 title: Release Controls
 wikipedia: https://en.wikipedia.org/wiki/Bruce_Willis
 weight: 200
+section: release
 ---

--- a/content/controls/build/_index.md
+++ b/content/controls/build/_index.md
@@ -18,3 +18,5 @@ It ensures that every stage, from code development to deployment, is safeguarded
 Without a secure build chain, vulnerabilities can be introduced at various points, leading to compromised software that could be exploited by attackers, potentially resulting in data breaches, system disruptions, and reputational damage.
 
 {{< /columns >}}
+
+{{< section_cards >}}

--- a/content/controls/lifecycle/_index.md
+++ b/content/controls/lifecycle/_index.md
@@ -16,3 +16,5 @@ Lifecycle controls ensure that teams maintain the knowledge, skills, and process
 They address the human and organisational factors that underpin a healthy security culture.
 
 {{< /columns >}}
+
+{{< section_cards >}}

--- a/content/controls/release/_index.md
+++ b/content/controls/release/_index.md
@@ -17,3 +17,5 @@ It ensures that key oversight and guardrails are applied to our software develop
 
 
 {{< /columns >}}
+
+{{< section_cards >}}

--- a/content/controls/runtime/_index.md
+++ b/content/controls/runtime/_index.md
@@ -16,3 +16,5 @@ A secure change management proces is critical to protect the software developmen
 It ensures that key oversight and guardrails are applied in our operations.
 
 {{< /columns >}}
+
+{{< section_cards >}}

--- a/content/risks/insider_threat.md
+++ b/content/risks/insider_threat.md
@@ -22,7 +22,7 @@ mitigations:
   - name: "Deployment Controls"
     url: "/controls/runtime/deployment_controls/"
   - name: "Training"
-    url: "/controls/training/"
+    url: "/controls/lifecycle/training/"
 ---
 
 # {{% param "title" %}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,7 +9,9 @@
       var saved = localStorage.getItem('theme');
       if (saved) {
         document.documentElement.setAttribute('data-theme', saved);
-      } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      } else if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+        document.documentElement.setAttribute('data-theme', 'light');
+      } else {
         document.documentElement.setAttribute('data-theme', 'dark');
       }
     })();

--- a/layouts/partials/docs/inject/body.html
+++ b/layouts/partials/docs/inject/body.html
@@ -6,7 +6,7 @@
   function getPreferredTheme() {
     var saved = localStorage.getItem('theme');
     if (saved) return saved;
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
   }
 
   function applyTheme(theme) {

--- a/layouts/partials/risk_cards.html
+++ b/layouts/partials/risk_cards.html
@@ -1,7 +1,10 @@
 <div class="card-row">
   {{ range $index, $page := .Pages.ByWeight }}
     <a class="risk-card card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
-      {{ $page.LinkTitle }}
+      {{ with $page.Params.risk_id }}
+      <div class="risk-id">{{ . }}:</div>
+      {{ end }}
+      <div class="risk-name">{{ $page.LinkTitle }}</div>
     </a>
   {{ end }}
 </div>

--- a/layouts/shortcodes/home_map.html
+++ b/layouts/shortcodes/home_map.html
@@ -9,7 +9,7 @@
     {{ with ($.Site.GetPage (printf "/%s" $taxonomy_name)) }}
       {{ range $index, $weightedArea := .Pages.ByWeight }}
 
-        <a href="/process/{{ .Page.Data.Term }}">
+        <a href="/controls/{{ with .Page.Params.section }}{{ . }}{{ else }}{{ .Page.Data.Term }}{{ end }}/">
           <h3 class="area-subheader area-{{ .Page.Data.Term }}">{{ .Page.LinkTitle }}</h3>
         </a>
 

--- a/layouts/shortcodes/map.html
+++ b/layouts/shortcodes/map.html
@@ -7,7 +7,7 @@
 						{{ range $index, $weightedArea:= .Pages.ByWeight }}  <!-- iterate by area weight -->
               
               <!-- Print area header  (e.g. "Build")-->
-              <a href="/process/{{ .Page.Data.Term }}">
+              <a href="/controls/{{ with .Page.Params.section }}{{ . }}{{ else }}{{ .Page.Data.Term }}{{ end }}/">
                 <h2 class="area-header">
                   {{ .Page.LinkTitle }}
                 </h2>

--- a/layouts/shortcodes/risk_head.html
+++ b/layouts/shortcodes/risk_head.html
@@ -6,8 +6,22 @@
 </blockquote>
 
 <h3>Mapped Controls</h3>
-<ul>
-{{ range .Page.Params.mitigations }}
-  <li><a href="{{ .url }}">{{ .name }}</a></li>
+<div class="card-row">
+{{ range $index, $mitigation := .Page.Params.mitigations }}
+  {{ $page := $.Page.Site.GetPage $mitigation.url }}
+  {{ $area := "" }}
+  {{ with $page }}
+    {{ with .Params.areas }}
+      {{ $area = index . 0 }}
+    {{ end }}
+  {{ end }}
+  <a class="control-card area-{{ $area }} card-index-{{ $index }}" href="{{ $mitigation.url }}">
+    {{ with $page }}
+      {{ with .Params.control_code }}
+      <div class="control-code">{{ . }}:</div>
+      {{ end }}
+    {{ end }}
+    <div class="control-name">{{ $mitigation.name }}</div>
+  </a>
 {{ end }}
-</ul>
+</div>

--- a/layouts/shortcodes/section_cards.html
+++ b/layouts/shortcodes/section_cards.html
@@ -1,0 +1,17 @@
+{{ $section := .Page.CurrentSection }}
+{{ $area := "" }}
+{{ range $section.Pages }}
+  {{ with .Params.areas }}
+    {{ $area = index . 0 }}
+  {{ end }}
+{{ end }}
+<div class="card-row">
+  {{ range $index, $page := $section.Pages.ByWeight }}
+    <a class="control-card area-{{ $area }} card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
+      {{ with $page.Params.control_code }}
+      <div class="control-code">{{ . }}:</div>
+      {{ end }}
+      <div class="control-name">{{ $page.LinkTitle }}</div>
+    </a>
+  {{ end }}
+</div>

--- a/themes/hugo-book/assets/_custom.scss
+++ b/themes/hugo-book/assets/_custom.scss
@@ -439,7 +439,21 @@ h2.area-header{
     font-size: 16px;
     color: #2a3040 !important;
     font-weight: 600;
+    overflow: hidden;
     background-color: var(--red-300);
+    .risk-id {
+        font-size: 10px;
+        font-weight: 400;
+        opacity: 0.7;
+        margin-bottom: 2px;
+    }
+    .risk-name {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
     &:hover {
         background-color: var(--blue-500) !important;
         border-color: var(--blue-500) !important;


### PR DESCRIPTION
## Summary
- **Dark mode default**: Default to dark mode when no browser preference or localStorage setting exists
- **Risk IDs on tiles**: Display `SDLC-RISK-XXXX` identifiers on risk cards, matching control card style
- **Fix area title links**: Area subheader links (e.g. "Build Controls", "Release Controls") now point to correct content paths instead of 404ing
- **Control tiles on area pages**: Each control area landing page (build, release, runtime, lifecycle) now shows its controls as clickable tiles
- **Control tiles on risk pages**: Mapped controls on risk pages displayed as color-coded tiles instead of bullet-point lists

## Test plan
- [x] Home page loads in dark mode by default (clear localStorage first)
- [x] Theme toggle switches between light/dark and persists
- [x] Risk tiles show `SDLC-RISK-XXXX` labels
- [x] Area title links navigate to correct pages (not 404)
- [x] Each control area landing page shows control tiles
- [x] Risk pages show mapped controls as colored tiles with correct area colors
- [x] Training tile on Insider Threat page has correct lifecycle color

🤖 Generated with [Claude Code](https://claude.com/claude-code)