### PR TITLE
Display mitigated risks as tiles on control pages

### DIFF
--- a/layouts/shortcodes/area_head.html
+++ b/layouts/shortcodes/area_head.html
@@ -9,38 +9,37 @@
 </blockquote>
 
 {{/* Reverse-lookup: find which risks this control mitigates.
-     Each risk page in /risk_register/ has a "mitigations" list in its
+     Each risk page in /risks/ has a "mitigations" list in its
      front matter with url/name pairs pointing to control pages.
      We check each risk's mitigations to see if any url matches
      the current control page's permalink. */}}
 {{ $currentURL := .Page.RelPermalink }}
 
-{{/* Get all child pages of the risk_register section */}}
-{{ $risks := (site.GetPage "/risk_register").Pages }}
+{{/* Get all child pages of the risks section */}}
+{{ $risks := (.Page.Site.GetPage "/risks").Pages }}
 
-{{/* Build a list of matching risks by scanning each risk's mitigations */}}
+{{/* Build a list of matching risk pages by scanning each risk's mitigations */}}
 {{ $matched := slice }}
 {{ range $risks }}
-  {{/* Capture risk page title and URL before entering the inner range,
-       because $ inside a shortcode's nested range refers to the shortcode
-       context, not the current page in the outer range */}}
-  {{ $riskTitle := .Title }}
-  {{ $riskURL := .RelPermalink }}
+  {{ $riskPage := . }}
   {{ range .Params.mitigations }}
-    {{/* If this mitigation's url points to the current control page,
-         add the risk to the matched list */}}
     {{ if eq .url $currentURL }}
-      {{ $matched = $matched | append (dict "name" $riskTitle "url" $riskURL) }}
+      {{ $matched = $matched | append $riskPage }}
     {{ end }}
   {{ end }}
 {{ end }}
 
 {{/* Only render the section if at least one risk references this control */}}
 {{ if $matched }}
-<h3>Mitigated Risks</h3>
-<ul>
-{{ range $matched }}
-  <li><a href="{{ .url }}">{{ .name }}</a></li>
+<h3>Mitigates Risk</h3>
+<div class="card-row">
+{{ range $index, $risk := $matched }}
+  <a class="risk-card card-index-{{ $index }}" href="{{ $risk.RelPermalink }}">
+    {{ with $risk.Params.risk_id }}
+    <div class="risk-id">{{ . }}:</div>
+    {{ end }}
+    <div class="risk-name">{{ $risk.LinkTitle }}</div>
+  </a>
 {{ end }}
-</ul>
+</div>
 {{ end }}


### PR DESCRIPTION
## Summary
- Added a "Mitigates Risk" section to each control page showing risk card tiles
- Fixed broken section path (`/risk_register/` → `/risks/`) that prevented the section from ever rendering
- Risk tiles use the same `risk-card` styling as the home page and risk index (risk ID label + risk name)

## Test plan
- [x] Verified Binary Provenance control page shows 3 risk tiles (Supply Chain Compromise, Unauthorised Deployment, Audit and Compliance Failure)
- [x] Verified Secrets Management control page shows 3 risk tiles (Insider Threat, Credential and Secret Exposure, Unauthorised System Access)
- [x] Confirmed tile dimensions (140px × 140px) and font size (16px) match the home page risk tiles exactly
- [x] Confirmed risk ID labels and risk name divs match the home page card structure
- [x] No console or server errors
- [x] Hugo builds cleanly with no warnings