### PR TITLE
Add risk descriptions and extract shared card partials

### DIFF
--- a/content/risks/audit_and_compliance_failure.md
+++ b/content/risks/audit_and_compliance_failure.md
@@ -21,3 +21,30 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Audit and Compliance Failure occurs when an organisation cannot produce sufficient evidence that its software development and operational controls are functioning as intended. This risk is not about the absence of controls themselves, but about the inability to demonstrate their existence and effectiveness to regulators, auditors, or enterprise customers. It arises from gaps in record-keeping, inconsistent control enforcement, lack of traceability between changes and approvals, or reliance on manual processes that leave insufficient audit trails. In regulated industries, the burden of proof lies with the organisation—controls that cannot be evidenced are treated as controls that do not exist.
+
+- **Gaps in change records** - Missing or incomplete records linking code changes to reviews, approvals, and deployments, making it impossible to reconstruct the history of what was deployed and why
+- **Inconsistent control enforcement** - Controls that are sometimes applied and sometimes bypassed, producing an unreliable evidence trail that fails to satisfy audit requirements
+- **Manual and undocumented processes** - Reliance on informal approvals, verbal sign-offs, or manual steps that leave no verifiable record of compliance
+- **Fragmented tooling and evidence** - Compliance evidence scattered across disconnected systems (ticketing tools, CI/CD logs, email threads) with no unified view or correlation
+- **Inability to demonstrate continuous compliance** - Point-in-time evidence that does not show ongoing adherence to controls between audit periods
+
+## Consequences
+The consequences of audit and compliance failure materializing for a financial institution can be severe:
+
+- **Regulatory Enforcement Actions:** Failure to demonstrate effective controls to banking regulators can result in formal enforcement actions, restrictions on business activities, increased supervisory scrutiny, and mandated remediation programs.
+
+- **Financial Penalties:** Regulators can impose significant fines for non-compliance with SOX, PCI DSS, DORA, and other applicable frameworks, with penalties scaling based on the severity and duration of compliance gaps.
+
+- **Loss of Licences and Certifications:** Sustained inability to evidence controls can jeopardise banking licences, payment processing certifications (PCI DSS), and other authorisations essential to operating in financial services.
+
+- **Failed Customer and Partner Audits:** Enterprise customers and partners increasingly require evidence of SDLC controls as part of vendor due diligence. Audit failures can result in lost contracts, exclusion from procurement processes, and damage to commercial relationships.
+
+- **Increased Audit Costs:** Organisations that cannot efficiently produce compliance evidence face prolonged audit cycles, higher audit fees, and the need for expensive remediation efforts to reconstruct missing evidence.
+
+- **Reputational Damage:** Public disclosure of regulatory enforcement actions or compliance failures signals poor governance to customers, partners, and the market, potentially impacting share price and customer confidence.
+
+- **Operational Burden:** Reactive compliance—scrambling to produce evidence in response to audit requests—diverts engineering and management resources from productive work and creates a cycle of perpetual catch-up.

--- a/content/risks/configuration_drift.md
+++ b/content/risks/configuration_drift.md
@@ -17,3 +17,30 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Configuration Drift occurs when the actual state of infrastructure, application configuration, or deployment environments diverges from the known, approved, and version-controlled state. This divergence can result from manual changes applied directly to production systems, emergency fixes that are never reconciled with the source of truth, inconsistent configuration management practices, or failures in infrastructure-as-code pipelines. Configuration drift is particularly insidious because changes accumulate silently over time, creating a growing gap between what the organisation believes is running and what is actually deployed. This gap undermines security controls, complicates incident response, and erodes confidence in the environment's integrity.
+
+- **Manual production changes** - Ad hoc modifications applied directly to production infrastructure or application configuration outside the standard change management process
+- **Unreconstructed emergency fixes** - Hotfixes or emergency changes applied during incidents that are never backported to the source of truth in version control
+- **Infrastructure-as-code divergence** - Drift between declared infrastructure definitions and the actual state of cloud resources, network configurations, or security groups
+- **Environment inconsistency** - Development, staging, and production environments falling out of alignment, leading to untested configuration combinations reaching production
+- **Untracked configuration drift** - Changes to feature flags, runtime parameters, database schemas, or third-party integrations that are not captured in version control or change records
+
+## Consequences
+The consequences of configuration drift materializing for a financial institution can be severe:
+
+- **Silent Security Degradation:** Drifted configurations can inadvertently weaken security controls—opening firewall rules, disabling encryption, relaxing authentication policies, or exposing services to unauthorised networks—without any alert or record.
+
+- **Unpredictable System Behaviour:** Applications running with configuration that differs from the tested and approved state may exhibit unexpected behaviour, data processing errors, or transaction failures that are difficult to diagnose.
+
+- **Failed Disaster Recovery:** Recovery procedures based on version-controlled configuration will restore systems to a state that differs from what was actually running, potentially causing data loss, service failures, or incomplete recovery.
+
+- **Regulatory Non-Compliance:** Regulators expect that organisations can demonstrate the current state of their systems and that changes are controlled and auditable. Configuration drift directly undermines this expectation and can trigger findings in regulatory examinations.
+
+- **Complicated Incident Response:** When the actual state of systems is unknown or differs from documentation, incident responders cannot reliably assess the scope of a compromise or determine whether specific controls were in place at the time of an incident.
+
+- **Increased Operational Risk:** Teams making changes based on stale documentation or incorrect assumptions about the current environment are more likely to cause outages, introduce conflicts, or break dependent services.
+
+- **Erosion of Trust in Automation:** When manual changes routinely override automated configuration management, teams lose confidence in infrastructure-as-code processes, leading to a cycle of increasing manual intervention and further drift.

--- a/content/risks/credential_and_secret_exposure.md
+++ b/content/risks/credential_and_secret_exposure.md
@@ -17,3 +17,28 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Credential and Secret Exposure occurs when sensitive authentication material—such as API keys, database passwords, service account tokens, encryption keys, or certificates—is inadvertently or deliberately exposed in locations where it can be accessed by unauthorised parties. This commonly happens through secrets committed to version control repositories, hardcoded credentials in application code, secrets leaked in CI/CD logs and artifacts, or credentials stored in insufficiently protected configuration management systems. Once exposed, credentials can be harvested by attackers and used to gain unauthorised access to production systems, customer data, and internal infrastructure.
+
+- **Secrets committed to source control** - API keys, passwords, or tokens checked into Git repositories where they persist in history even after removal from the working tree
+- **Hardcoded credentials in application code** - Database connection strings, service account passwords, or encryption keys embedded directly in source files rather than injected at runtime
+- **CI/CD log leakage** - Build and deployment pipelines inadvertently printing secrets to log output, making them visible to anyone with access to pipeline logs
+- **Insecure secret storage** - Credentials stored in plaintext configuration files, environment variables without encryption, shared documents, or messaging platforms
+- **Overprivileged service credentials** - Service accounts or API keys granted excessive permissions, amplifying the blast radius if the credential is compromised
+
+## Consequences
+The consequences of credential and secret exposure materializing for a financial institution can be severe:
+
+- **Unauthorised Access to Production Systems:** Exposed credentials provide attackers with direct access to databases, APIs, cloud infrastructure, and internal services, enabling data theft, transaction manipulation, or system compromise.
+
+- **Customer Data Breach:** Compromised database credentials or API keys can be used to exfiltrate customer PII, account details, and financial records, triggering breach notification obligations under GDPR, CCPA, and GLBA.
+
+- **CI/CD Pipeline Compromise:** Leaked pipeline credentials enable attackers to tamper with build and deployment processes, injecting malicious code into artefacts destined for production.
+
+- **Regulatory Penalties:** Inadequate secrets management violates requirements under PCI DSS, SOX, and banking supervisory standards, exposing the institution to fines, enforcement actions, and mandated remediation programs.
+
+- **Reputational Damage:** Public disclosure that customer-facing systems were compromised through leaked credentials—particularly if customer funds or data were affected—severely damages institutional trust.
+
+- **Costly Remediation:** Responding to credential exposure requires emergency rotation of all potentially affected secrets, forensic investigation to determine the scope of compromise, and potential rebuilding of affected systems—all under significant time pressure.

--- a/content/risks/environment_breach.md
+++ b/content/risks/environment_breach.md
@@ -11,3 +11,30 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Environment Breach occurs when an external attacker gains the ability to run unauthorised workloads within an organisation's production infrastructure. This goes beyond simple data access—the attacker establishes a persistent operational presence, executing their own code, deploying containers or processes, and using the organisation's compute resources for malicious purposes. This can result from exploitation of vulnerabilities in exposed services, compromised container orchestration platforms, misconfigured cloud IAM policies, or abuse of legitimate deployment mechanisms. An environment breach represents a severe compromise because the attacker operates within the organisation's own infrastructure, making detection significantly harder and the potential impact far greater.
+
+- **Unauthorised container or workload deployment** - Attackers deploying their own containers, serverless functions, or processes within the organisation's orchestration platform (e.g., Kubernetes, ECS)
+- **Compromised orchestration plane** - Exploitation of container orchestration APIs or management interfaces to schedule and run attacker-controlled workloads alongside legitimate services
+- **Cryptojacking and resource abuse** - Attackers deploying cryptocurrency mining workloads or using compromised infrastructure for computational tasks, consuming resources and increasing costs
+- **Staging ground for further attacks** - Using the breached environment as a launch point for lateral movement into other internal systems, data stores, or connected partner networks
+- **Persistent backdoor deployment** - Installing persistent access mechanisms such as reverse shells, web shells, or rogue services that survive routine maintenance and restarts
+
+## Consequences
+The consequences of an environment breach materializing for a financial institution can be severe:
+
+- **Complete Infrastructure Compromise:** An attacker running workloads in production has deep access to the environment, potentially including network access to databases, internal APIs, secret stores, and adjacent systems that are not directly exposed to the internet.
+
+- **Customer Data Theft at Scale:** With operational presence in the production environment, attackers can systematically exfiltrate customer data, transaction records, and financial information over extended periods while evading perimeter-based detection.
+
+- **Financial Losses from Resource Abuse:** Unauthorised workloads—particularly cryptomining operations—can generate significant unexpected cloud computing costs before detection, directly impacting operational budgets.
+
+- **Regulatory Escalation:** An environment breach represents a fundamental control failure. Regulators will treat the ability of an external attacker to run workloads in a financial institution's production environment as a critical finding requiring immediate remediation and likely triggering formal enforcement proceedings.
+
+- **Supply Chain Risk to Customers:** Attacker-controlled workloads running within the institution's infrastructure can potentially intercept, modify, or inject data into legitimate business processes, affecting downstream customers and partners.
+
+- **Prolonged and Costly Incident Response:** Detecting and eradicating an attacker with operational presence requires thorough forensic investigation of all running workloads, comprehensive review of deployment history, and potentially rebuilding affected infrastructure from known-good state.
+
+- **Reputational Catastrophe:** Disclosure that an external attacker was running their own workloads inside a financial institution's production environment represents a severe breach of trust that can permanently damage the institution's standing with customers, partners, and regulators.

--- a/content/risks/unauthorised_deployment.md
+++ b/content/risks/unauthorised_deployment.md
@@ -17,3 +17,28 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Unauthorised Deployment occurs when software artefacts reach production environments without completing the required quality gates, security validations, or approval workflows. This can happen through misconfigured CI/CD pipelines, direct manual deployments that bypass automated controls, or exploitation of overly permissive deployment credentials. The risk is compounded in environments where deployment tooling lacks sufficient access controls or where emergency "break-glass" procedures are poorly governed and frequently abused.
+
+- **Pipeline bypass** - Developers or operators deploying directly to production outside the sanctioned CI/CD pipeline, circumventing automated checks and approval gates
+- **Incomplete quality gates** - Artefacts promoted to production despite failing tests, security scans, or compliance checks due to misconfigured or overridden pipeline stages
+- **Unverified artefact provenance** - Deploying binaries or container images whose origin cannot be traced back to a verified source repository and build process
+- **Abuse of emergency deployment procedures** - Overuse or misuse of break-glass mechanisms intended for critical incidents, resulting in unreviewed code reaching production
+- **Credential and role misconfiguration** - Deployment service accounts or roles granting broader access than necessary, allowing unauthorised personnel to trigger production deployments
+
+## Consequences
+The consequences of an unauthorised deployment materializing for a financial institution can be severe:
+
+- **Introduction of Untested Code into Production:** Software that has not passed security scans, functional tests, or compliance checks may contain vulnerabilities, logic errors, or regressions that directly impact transaction processing, account management, or customer-facing services.
+
+- **Regulatory Non-Compliance:** Financial regulators require demonstrable change management controls. Deployments that bypass approval workflows violate requirements under SOX, PCI DSS, and banking supervisory standards, potentially triggering enforcement actions and mandatory remediation.
+
+- **Loss of Audit Trail Integrity:** Unauthorised deployments create gaps in change records, making it impossible to reconstruct what was deployed, when, and by whom—undermining incident investigation and regulatory audit readiness.
+
+- **Service Outages and Operational Disruption:** Unvalidated deployments increase the likelihood of production incidents, including service degradation, data corruption, or complete system outages affecting customers and downstream systems.
+
+- **Security Exposure:** Code that has not undergone security review or vulnerability scanning may introduce exploitable weaknesses, creating entry points for attackers to access sensitive financial data or critical infrastructure.
+
+- **Reputational Damage:** Customer-visible incidents caused by uncontrolled deployments—particularly those affecting account balances, payment processing, or data privacy—erode trust and can lead to customer attrition.

--- a/content/risks/unauthorised_system_access.md
+++ b/content/risks/unauthorised_system_access.md
@@ -13,3 +13,30 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Unauthorised System Access occurs when individuals gain access to production environments, infrastructure, or sensitive systems without appropriate authorisation or without their access being fully recorded and auditable. This includes scenarios where access controls are too broad, where former employees or contractors retain active credentials, where shared accounts obscure individual accountability, or where privileged access is granted without time-bound restrictions or proper justification. The risk extends to both external attackers who exploit weak access controls and internal personnel whose access exceeds their legitimate operational needs.
+
+- **Overprivileged access** - Users or service accounts granted broader permissions than required for their role, providing unnecessary access to sensitive systems, data, or infrastructure
+- **Stale access credentials** - Former employees, contractors, or rotated team members retaining active access to production systems after their need for access has ended
+- **Shared and generic accounts** - Use of shared credentials or service accounts that obscure which individual performed a given action, undermining accountability and audit trails
+- **Insufficient access logging** - Systems that do not record who accessed what, when, and from where, making it impossible to detect or investigate unauthorised access
+- **Lack of time-bound or just-in-time access** - Persistent privileged access that remains active indefinitely rather than being granted on-demand for specific, justified operational needs
+
+## Consequences
+The consequences of unauthorised system access materializing for a financial institution can be severe:
+
+- **Data Breach and Exfiltration:** Unauthorised access to production databases, customer records, or internal systems enables theft of sensitive financial data, PII, and intellectual property.
+
+- **Fraudulent Transactions:** Access to transaction processing systems, payment infrastructure, or account management tools can be exploited to initiate unauthorised transfers, manipulate account balances, or conduct fraudulent activities.
+
+- **Regulatory Violations:** Financial regulators require strict access controls and audit trails for production systems. Inadequate access governance violates requirements under SOX, PCI DSS, and banking supervisory standards, triggering enforcement actions.
+
+- **Loss of Accountability:** Shared accounts and insufficient logging make it impossible to attribute actions to specific individuals, undermining incident investigation, forensic analysis, and regulatory reporting obligations.
+
+- **Lateral Movement by Attackers:** Overly broad access permissions enable attackers who compromise a single account to move laterally across the environment, escalating from low-value systems to critical infrastructure.
+
+- **Reputational Damage:** Disclosure that customer data or financial systems were accessed by unauthorised individuals—particularly through preventable access control failures—severely erodes customer trust and market confidence.
+
+- **Prolonged Undetected Compromise:** Without comprehensive access logging and monitoring, unauthorised access can persist undetected for extended periods, increasing the scope and severity of potential damage.

--- a/content/risks/vulnerable_software_in_production.md
+++ b/content/risks/vulnerable_software_in_production.md
@@ -17,3 +17,26 @@ mitigations:
 
 # {{% param "title" %}}
 {{< risk_head >}}
+
+
+## Description
+Vulnerable Software in Production occurs when applications or their dependencies containing known security vulnerabilities are deployed to and remain running in production environments. This risk arises from inadequate vulnerability scanning during the build and release process, failure to keep dependencies up to date, delayed patching of known CVEs, or insufficient visibility into the software composition of running workloads. Attackers actively scan for known vulnerabilities and can exploit them rapidly once public disclosures are made, making timely detection and remediation critical.
+
+- **Unpatched known vulnerabilities (CVEs)** - Production systems running software with publicly disclosed vulnerabilities for which patches or mitigations are available but have not been applied
+- **Outdated or end-of-life dependencies** - Libraries, frameworks, or runtime components that no longer receive security updates, leaving known vulnerabilities permanently unaddressed
+- **Incomplete vulnerability scanning** - Security scans that do not cover the full software stack—including transitive dependencies, container base images, and runtime libraries—leaving blind spots in vulnerability detection
+- **Delayed remediation cycles** - Organisational processes that are too slow to triage, prioritise, and deploy fixes for critical vulnerabilities before they can be exploited
+- **Shadow dependencies** - Components pulled in through indirect or undocumented dependency chains that are not tracked or scanned as part of the standard build process
+
+## Consequences
+The consequences of vulnerable software in production materializing for a financial institution can be severe:
+
+- **Active Exploitation by Attackers:** Known vulnerabilities with public exploit code can be weaponised rapidly. Attackers target financial institutions specifically because of the value of the data and systems they protect.
+
+- **Customer Data Breach:** Exploited vulnerabilities in web-facing applications or APIs can expose customer PII, account credentials, and transaction histories, triggering regulatory breach notification requirements.
+
+- **Regulatory Non-Compliance:** Financial regulators expect timely vulnerability management as a core security control. Running known-vulnerable software violates requirements under PCI DSS, banking supervisory standards, and enterprise risk management frameworks.
+
+- **Service Disruption:** Exploitation of vulnerabilities can lead to denial of service, data corruption, or system compromise that forces emergency shutdowns of customer-facing services.
+
+- **Reputational Damage:** Public disclosure that a breach resulted from a known, unpatched vulnerability is particularly damaging, as it signals failure of basic security hygiene to customers, partners, and regulators.

--- a/layouts/partials/control_card.html
+++ b/layouts/partials/control_card.html
@@ -1,0 +1,6 @@
+<a class="control-card area-{{ .area }} card-index-{{ .index }}" href="{{ .page.RelPermalink }}">
+  {{ with .page.Params.control_code }}
+  <div class="control-code">{{ . }}:</div>
+  {{ end }}
+  <div class="control-name">{{ .page.LinkTitle }}</div>
+</a>

--- a/layouts/partials/risk_card.html
+++ b/layouts/partials/risk_card.html
@@ -1,0 +1,6 @@
+<a class="risk-card card-index-{{ .index }}" href="{{ .page.RelPermalink }}">
+  {{ with .page.Params.risk_id }}
+  <div class="risk-id">{{ . }}:</div>
+  {{ end }}
+  <div class="risk-name">{{ .page.LinkTitle }}</div>
+</a>

--- a/layouts/partials/risk_cards.html
+++ b/layouts/partials/risk_cards.html
@@ -1,10 +1,5 @@
 <div class="card-row">
   {{ range $index, $page := .Pages.ByWeight }}
-    <a class="risk-card card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
-      {{ with $page.Params.risk_id }}
-      <div class="risk-id">{{ . }}:</div>
-      {{ end }}
-      <div class="risk-name">{{ $page.LinkTitle }}</div>
-    </a>
+    {{ partial "risk_card.html" (dict "page" $page "index" $index) }}
   {{ end }}
 </div>

--- a/layouts/shortcodes/area_head.html
+++ b/layouts/shortcodes/area_head.html
@@ -34,12 +34,7 @@
 <h3>Mitigates Risk</h3>
 <div class="card-row">
 {{ range $index, $risk := $matched }}
-  <a class="risk-card card-index-{{ $index }}" href="{{ $risk.RelPermalink }}">
-    {{ with $risk.Params.risk_id }}
-    <div class="risk-id">{{ . }}:</div>
-    {{ end }}
-    <div class="risk-name">{{ $risk.LinkTitle }}</div>
-  </a>
+  {{ partial "risk_card.html" (dict "page" $risk "index" $index) }}
 {{ end }}
 </div>
 {{ end }}

--- a/layouts/shortcodes/home_map.html
+++ b/layouts/shortcodes/home_map.html
@@ -19,12 +19,7 @@
             {{ if eq $area $term }}
               <div class="card-row">
                 {{ range $index, $card := $cards }}
-                  <a class="control-card area-{{ $term }} card-index-{{ $index }}" href="{{ .RelPermalink }}">
-                    {{ with .Params.control_code }}
-                    <div class="control-code">{{ . }}:</div>
-                    {{ end }}
-                    <div class="control-name">{{ .LinkTitle }}</div>
-                  </a>
+                  {{ partial "control_card.html" (dict "page" . "area" $term "index" $index) }}
                 {{ end }}
               </div>
             {{ end }}

--- a/layouts/shortcodes/risk_head.html
+++ b/layouts/shortcodes/risk_head.html
@@ -14,14 +14,7 @@
     {{ with .Params.areas }}
       {{ $area = index . 0 }}
     {{ end }}
+    {{ partial "control_card.html" (dict "page" $page "area" $area "index" $index) }}
   {{ end }}
-  <a class="control-card area-{{ $area }} card-index-{{ $index }}" href="{{ $mitigation.url }}">
-    {{ with $page }}
-      {{ with .Params.control_code }}
-      <div class="control-code">{{ . }}:</div>
-      {{ end }}
-    {{ end }}
-    <div class="control-name">{{ $mitigation.name }}</div>
-  </a>
 {{ end }}
 </div>

--- a/layouts/shortcodes/section_cards.html
+++ b/layouts/shortcodes/section_cards.html
@@ -7,11 +7,6 @@
 {{ end }}
 <div class="card-row">
   {{ range $index, $page := $section.Pages.ByWeight }}
-    <a class="control-card area-{{ $area }} card-index-{{ $index }}" href="{{ $page.RelPermalink }}">
-      {{ with $page.Params.control_code }}
-      <div class="control-code">{{ . }}:</div>
-      {{ end }}
-      <div class="control-name">{{ $page.LinkTitle }}</div>
-    </a>
+    {{ partial "control_card.html" (dict "page" $page "area" $area "index" $index) }}
   {{ end }}
 </div>


### PR DESCRIPTION
## Summary
- Add Description and Consequences sections to all 7 remaining risk pages (SDLC-RISK-0003 through SDLC-RISK-0009), matching the pattern established by Supply Chain Compromise and Insider Threat
- Extract shared `control_card.html` and `risk_card.html` partials to eliminate duplicated card markup across templates
- Fix risk page control cards to use the page title (`.LinkTitle`) instead of the mitigation name from frontmatter, so card text is consistent across all pages

## Test plan
- [x] Hugo builds without errors
- [x] Home page renders risk cards and control cards correctly
- [x] Risk pages render mapped control cards with correct titles matching home page
- [x] Control pages render "Mitigates Risk" cards correctly
- [x] Section pages (e.g. Build Controls) render control cards correctly
- [x] No console or server errors
- [x] Content review of all 7 risk Description and Consequences sections
- [x] Verify all mitigation links on risk pages resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)